### PR TITLE
Move timeseries data not found in incoming data to an expire directory

### DIFF
--- a/private/eseses/timeseries.py
+++ b/private/eseses/timeseries.py
@@ -5,8 +5,6 @@ import shutil
 import os
 import glob
 import subprocess
-import time
-from dateutil import parser
 from ftplib import FTP
 
 if not os.path.exists('./data'):
@@ -17,6 +15,7 @@ if not os.path.exists('./data/comb'):
     os.makedirs('data/comb')
 if not os.path.exists('./data/sopac'):
     os.makedirs('data/sopac')
+
 
 def fetch_data(server, directory):
 
@@ -33,7 +32,7 @@ def fetch_data(server, directory):
     for line in lines:
         tokens = line.split()
         name = tokens[8]
-        if str(name).endswith('.tar.gz'): 
+        if str(name).endswith('.tar.gz'):
             files.append(name)
 
     # download files
@@ -57,47 +56,72 @@ def fetch_data(server, directory):
             print('Skipping already extracted ' + gztar)
         else:
             print('Unzipping ' + gztar)
-            with gzip.open(gztar,'rb') as f_in:
-              with open(tarfn,'wb') as f_out:
-                shutil.copyfileobj(f_in,f_out)
-            tar = tarfile.open(tarfn)
-            extract_dir = './data'
-            if '_jpl_' in tarfn:
-                source = 'jpl'
-            if '_comb_' in tarfn:
-                source = 'comb'
-            if '_sopac_' in tarfn:
-                source = 'sopac'
-            if source in ['jpl','comb','sopac']:  # if not one of these, file will be discarded
-              print('Untarring ' + tarfn)
-              extract_dir = extract_dir + "/" + source
-              # need to limit to the relevant filename!
-              #for oldF in [f for f in os.listdir(extract_dir)]:
-              #  os.remove(os.path.join(extract_dir,oldF))
-              tar.extractall(extract_dir)
-              tar.close()
-              # truncate files
-              if  gztar in existing_files:
-                  print('Skipping already processed ' + gztar)
-              else:
-                  with open(gztar, 'w') as fp: # truncate file to save disk space
-                      print('Truncating data/' + gztar)
+            with gzip.open(gztar, 'rb') as f_in:
+                with open(tarfn, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            try:
+                tar = tarfile.open(tarfn)
+                extract_dir = './data'
+                if '_jpl_' in tarfn:
+                    source = 'jpl'
+                if '_comb_' in tarfn:
+                    source = 'comb'
+                if '_sopac_' in tarfn:
+                    source = 'sopac'
+                # if not one of these, file will be discarded
+                if source in ['jpl', 'comb', 'sopac']:
+                    print('Untarring ' + tarfn)
+                    extract_dir = extract_dir + "/" + source
+                    expire_dir = extract_dir + "/expire"
+                    if not os.path.exists(expire_dir):
+                        os.makedirs(expire_dir)
+
+                    file_list = tar.getnames()
+                    outsuffix = os.path.splitext(file_list[0])[0][4:]
+                    existing_files = set(glob.glob(extract_dir + '/*' + outsuffix))
+                    file_list_set = set([extract_dir + '/' + os.path.splitext(zfile)[0] for zfile in file_list])
+
+                    # Find files in existing_files but not in file_list
+                    only_in_existing_files = existing_files - file_list_set
+
+                    # Find files in file_list but not in existing_files
+                    only_in_file_list = file_list_set - existing_files
+
+                    # Expire old files
+                    for file in only_in_existing_files:
+                        print("Expiring file: " + file)
+                        # move to expire directory
+                        os.rename(file, os.path.join(expire_dir,
+                                                    os.path.basename(file)))
+                    for file in only_in_file_list:
+                        print("New file from tar: " + file)
+
+                    tar.extractall(extract_dir)
+                    tar.close()
+                    # truncate files
+                    if gztar in existing_files:
+                        print('Skipping already processed ' + gztar)
+                    else:
+                        with open(gztar, 'w') as fp:
+                            # truncate file to save disk space
+                            print('Truncating data/' + gztar)
+            except tarfile.ReadError:
+                print('Error reading ' + tarfn)
+                os.remove(gztar)
             print('Unlinking ' + tarfn)
             os.unlink(tarfn)
-
 
     # extract Z files
     print('Uncompressing files...')
     for tsfile in glob.glob('data/*/*.Z'):
         unzip_command = ['unzip', '-o', tsfile, '-d', os.path.dirname(tsfile)]
-        process = subprocess.Popen(unzip_command,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+        process = subprocess.Popen(
+            unzip_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         process.wait()
-        #for output in process.stdout:
-            #print output
         for error in process.stderr:
             print(error)
         os.remove(tsfile)
-        
+
 
 server = 'sopac-ftp.ucsd.edu'
 # fetch global data


### PR DESCRIPTION
- Move timeseries data not found in incoming data to an expire directory
- Expired files may be reviewed and purged later on

## Purpose
- Old timeseries files are not removed and need to be
## Proposed Changes
- Moves timeseries data not found in incoming data to an expire directory
## Issues
- Old timeseries files are not removed #5
## Testing
- Ran script to pull down new time series files and saw old files that are not found in incoming data moved to the expire directory
- Existing files that are found in incoming data are overwritten